### PR TITLE
Fix compatibility with Ubuntu 18.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,14 @@ build/tetris-CHR-01.chr: tetris.nes | build
 
 build/game_palette.pal: build/tetris-PRG.bin
 	# +3 for buildCopyToPpu header
-	tail -c +$$((16#ACF3 - 16#8000 + 3 + 1)) $< | head -c 16 > $@
+	tail -c +$$((0xACF3 - 0x8000 + 3 + 1)) $< | head -c 16 > $@
 build/menu_palette.pal: build/tetris-PRG.bin
 	# +3 for buildCopyToPpu header
-	tail -c +$$((16#AD2B - 16#8000 + 3 + 1)) $< | head -c 16 > $@
+	tail -c +$$((0xAD2B - 0x8000 + 3 + 1)) $< | head -c 16 > $@
 build/game_nametable.nam: build/tetris-PRG.bin
-	tail -c +$$((16#BF3C - 16#8000 + 1)) $< | head -c $$((1024/32*35)) | LC_ALL=C awk 'BEGIN {RS=".{35}";ORS=""} {print substr(RT, 4)}' > $@
+	tail -c +$$((0xBF3C - 0x8000 + 1)) $< | head -c $$((1024/32*35)) | LC_ALL=C awk 'BEGIN {RS=".{35}";ORS=""} {print substr(RT, 4)}' > $@
 build/level_menu_nametable.nam: build/tetris-PRG.bin
-	tail -c +$$((16#BADB - 16#8000 + 1)) $< | head -c $$((1024/32*35)) | LC_ALL=C awk 'BEGIN {RS=".{35}";ORS=""} {print substr(RT, 4)}' > $@
+	tail -c +$$((0xBADB - 0x8000 + 1)) $< | head -c $$((1024/32*35)) | LC_ALL=C awk 'BEGIN {RS=".{35}";ORS=""} {print substr(RT, 4)}' > $@
 
 build/tetris.inc: build/tetris.nes
 	sort build/tetris.lbl | sed -E -e 's/al 00(.{4}) .(.*)/\2 := $$\1/' | uniq > $@

--- a/nes.mk
+++ b/nes.mk
@@ -28,7 +28,10 @@ build/%.chrs/fake: %.chr | build
 	touch $@
 	split -x -b 16 $< build/$*.chrs/
 build/%.rle: % rle-enc.awk | build
-	basenc --base16 -w2 $< | LC_ALL=C awk -f rle-enc.awk | basenc --base16 -d > $@
+	# 'basenc --base16 -w2' and 'basenc --base16 -d' would also work, but
+	# basenc isn't as widely available as xxd since it was added in
+	# coreutils 8.31
+	xxd -c1 -p $< | LC_ALL=C awk -f rle-enc.awk | xxd -r -p > $@
 
 build/%.s: %.bin %.info Makefile | build
 	# Strip off the first two lines of header, which contain variable


### PR DESCRIPTION
This goes about compatibility a bit differently than #8. It makes itself compatible with dash instead of forcing bash. Forcing bash is fine, but fixing compatibility was a trivial change and improved readability. This also swaps to xxd unconditionally. It seems there are many copies of xxd floating between distributions, but all seem very old. Even Alpine has xxd, so it seems pretty safe.

In related news, TIL that cc65 is available on Ubuntu via a simple `apt install cc65`.

CC @rib, @TGGC