### PR TITLE
Disassembly: added local labels for scoring routines

### DIFF
--- a/tetris-PRG.info
+++ b/tetris-PRG.info
@@ -820,10 +820,10 @@ LABEL { ADDR $9C18; NAME "@noLowOverflow"; };
 LABEL { ADDR $9C27; NAME "@noHighOverflow"; };
 LABEL { ADDR $9C2D; NAME "addLineClearPoints"; };
 LABEL { ADDR $9C37; NAME "@pointsLoop"; };
-LABEL { ADDR $9C4E; NAME "@noScore0HighOverlow"; };
-LABEL { ADDR $9C64; NAME "@noScore1LowOverlow"; };
-LABEL { ADDR $9C75; NAME "@noScore1HighOverlow"; };
-LABEL { ADDR $9C84; NAME "@noScore2LowOverlow"; };
+LABEL { ADDR $9C4E; NAME "@noScore0HighOverflow"; };
+LABEL { ADDR $9C64; NAME "@noScore1LowOverflow"; };
+LABEL { ADDR $9C75; NAME "@noScore1HighOverflow"; };
+LABEL { ADDR $9C84; NAME "@noScore2LowOverflow"; };
 LABEL { ADDR $9C94; NAME "@noScoreCap"; };
 LABEL { ADDR $9CAF; NAME "updatePlayfield"; }; # canon
 LABEL { ADDR $9CB8; NAME "@rowInRange"; };

--- a/tetris-PRG.info
+++ b/tetris-PRG.info
@@ -816,7 +816,15 @@ LABEL { ADDR $9B96; NAME "@checkForBorrow"; };
 LABEL { ADDR $9BA6; NAME "@gameTypeA"; };
 LABEL { ADDR $9BA8; NAME "incrementLines"; };
 LABEL { ADDR $9BFE; NAME "addHoldDownPoints"; };
+LABEL { ADDR $9C18; NAME "@noLowOverflow"; };
+LABEL { ADDR $9C27; NAME "@noHighOverflow"; };
 LABEL { ADDR $9C2D; NAME "addLineClearPoints"; };
+LABEL { ADDR $9C37; NAME "@pointsLoop"; };
+LABEL { ADDR $9C4E; NAME "@noScore0HighOverlow"; };
+LABEL { ADDR $9C64; NAME "@noScore1LowOverlow"; };
+LABEL { ADDR $9C75; NAME "@noScore1HighOverlow"; };
+LABEL { ADDR $9C84; NAME "@noScore2LowOverlow"; };
+LABEL { ADDR $9C94; NAME "@noScoreCap"; };
 LABEL { ADDR $9CAF; NAME "updatePlayfield"; }; # canon
 LABEL { ADDR $9CB8; NAME "@rowInRange"; };
 LABEL { ADDR $9CBE; NAME "@ret"; };

--- a/twoplayer-tetris-PRG.s.diff
+++ b/twoplayer-tetris-PRG.s.diff
@@ -837,11 +837,11 @@
          ldx     #$00
  @inc:   iny
          cpy     #$C8
-@@ -3359,23 +3432,33 @@ L9C75:  lda     score+2
-         clc
+@@ -3359,11 +3432,16 @@ @noScore1HighOverflow:
          adc     #$06
          sta     score+2
- L9C84:  lda     score+2
+ @noScore2LowOverflow:
+         lda     score+2
          and     #$F0
 +.ifdef TOURNAMENT_MODE
 +        ;this basically is no real fix, it just disables the check
@@ -849,13 +849,14 @@
 +.else
          cmp     #$A0
 +.endif
-         bcc     L9C94
+         bcc     @noScoreCap
          lda     #$99
          sta     score
          sta     score+1
          sta     score+2
- L9C94:  dec     generalCounter
-         bne     L9C37
+@@ -3378,12 +3456,17 @@ @noScoreCap:
+         dec     generalCounter
+         bne     @pointsLoop
          lda     outOfDateRenderFlags
          ora     #$04
          sta     outOfDateRenderFlags


### PR DESCRIPTION
These are imperfect, but probably better than nothing.

Unfortunately for most of the labels it feels like it makes more sense for readability to describe them how they're used, rather than the code that follows. Them being local labels at least mitigates this issue a bit.

It was quite hard thinking up good names for these. Some alternative things I considered were Ones/Tens instead of Low/High, and instead of Score0/1/2 using Hundredths Myriadths and Millionths, but that looked awful.

Additionally, tested and works with `PAL=1` too